### PR TITLE
Provide ES2015 transpiled code

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "0.3.0",
   "description": "an rxjs subject that queues data when it has no observers",
   "main": "lib/index.js",
+  "module": "lib/es2015/index.js",
   "typings": "lib/index",
   "scripts": {
-    "build": "tsc -p src",
+    "build": "tsc -p src/tsconfig.json && tsc -p src/tsconfig.es2015.json",
     "lint": "tslint -p src/tsconfig.json",
     "watch": "tsc -w -p src"
   },

--- a/src/tsconfig.es2015.json
+++ b/src/tsconfig.es2015.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../lib/es2015",
+    "target": "es2015",
+  },
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -12,5 +12,6 @@
     "sourceMap": true,
     "strict": true,
     "target": "es5"
-  }
+  },
+  "include": ["."]
 }


### PR DESCRIPTION
Hi !

This pull request fixes #19 

The problem is the same as descrbied here: https://stackoverflow.com/questions/51860043/javascript-es6-typeerror-class-constructor-client-cannot-be-invoked-without-ne/51860850


```
export class QueueingSubject<T> extends Subject<T> {
```

is transpiled into

```
var QueueingSubject = /** @class */ (function (_super) {
    __extends(QueueingSubject, _super);
    function QueueingSubject() {
        var _this = _super !== null && _super.apply(this, arguments) || this;
        _this.queuedValues = [];
```


With this modification, es2015 code will be used if targeting `es2015` (notice the new `module` property in `package.json`)
